### PR TITLE
Ensure GPT-5 default model is reflected across NOFE

### DIFF
--- a/.github/workflows/nofe_daily.yml
+++ b/.github/workflows/nofe_daily.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run NOFE
         env:
           PYTHONPATH: src
-        run: python -m nofe.pipeline
+        run: python -m nofe.pipeline  # uses GPT-5 for AI analysis by default (see src/nofe/config.yaml)
 
       - name: Debug reports (optional)
         run: |

--- a/AI_ANALYSIS_README.md
+++ b/AI_ANALYSIS_README.md
@@ -18,7 +18,7 @@ AI analysis is controlled by settings in `src/config.yaml`:
 # AI analysis settings
 enable_ai_analysis: true        # Enable/disable AI analysis
 ai_analysis_inline: false      # Inline vs separate file output
-ai_model: "gpt-4o-mini"        # OpenAI model to use (optional)
+ai_model: "GPT-5"              # OpenAI model to use (optional)
 ```
 
 ### Settings Explained
@@ -27,7 +27,7 @@ ai_model: "gpt-4o-mini"        # OpenAI model to use (optional)
 - **`ai_analysis_inline`**: 
   - `false`: Creates separate `AI_CHAOS_YYYYMMDD.md` files
   - `true`: Appends AI analysis to the main CHAOS report
-- **`ai_model`**: Specifies which OpenAI model to use (defaults to "gpt-4o-mini")
+- **`ai_model`**: Specifies which OpenAI model to use (defaults to "GPT-5")
 
 ## API Key Setup
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ python src/nofe/pipeline.py
 
 Reports will be generated in `reports/` as `CHAOS_YYYYMMDD.md`.
 
+### AI Analysis Model
+
+If you enable the optional AI analysis module, NOFE will default to OpenAI's GPT-5 model. You can adjust the `ai_model` value in `src/nofe/config.yaml` if you need to target a different release.
+
 ## GitHub Actions Automation
 A workflow is provided in `.github/workflows/nofe_daily.yml` to automatically run the pipeline daily, commit the results to the repo, and push to the `main` branch.
 

--- a/src/nofe/ai_analysis.py
+++ b/src/nofe/ai_analysis.py
@@ -48,7 +48,7 @@ def generate_ai_analysis(report_text: str, cfg: Optional[Dict] = None) -> str:
     if not api_key:
         return "AI analysis skipped: missing OPENAI_API_KEY."
 
-    model = (cfg or {}).get("ai_model", "gpt-4o-mini")
+    model = (cfg or {}).get("ai_model", "GPT-5")
     messages = [
         {"role": "system", "content": SYSTEM_PROMPT},
         {"role": "user", "content": report_text[:120000]},  # safety truncation

--- a/src/nofe/config.yaml
+++ b/src/nofe/config.yaml
@@ -58,3 +58,4 @@ truth_vector:
 # AI analysis settings
 enable_ai_analysis: true
 ai_analysis_inline: false
+ai_model: "GPT-5"

--- a/src/nofe/pipeline.py
+++ b/src/nofe/pipeline.py
@@ -120,7 +120,7 @@ def main() -> None:
 
     # Optionally run AI analysis
     if cfg.get("enable_ai_analysis"):
-        ai_summary = generate_ai_analysis(report_text)
+        ai_summary = generate_ai_analysis(report_text, cfg=cfg)
         inline = cfg.get("ai_analysis_inline", False)
         if inline:
             # Append AI analysis to the same report


### PR DESCRIPTION
## Summary
- document the GPT-5 default in the main README and workflow guidance
- add the GPT-5 model selection to the runtime configuration and ensure the pipeline uses it
- clarify the GitHub Actions workflow comment about GPT-5 usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68efa1c96b74833194b9a2d482ce1447