### PR TITLE
Fix checkout conflicts in daily report workflow

### DIFF
--- a/.github/workflows/nofe_daily.yml
+++ b/.github/workflows/nofe_daily.yml
@@ -61,7 +61,26 @@ jobs:
           git config user.email "bot@example.com"
 
           git fetch origin main
+
+          # Avoid "untracked files would be overwritten" errors when the
+          # pipeline has already produced the new reports before we sync with
+          # origin/main.  By stashing the current workspace (including
+          # untracked files) we can safely fast-forward to the latest remote
+          # state and then restore the generated artifacts for committing.
+          stashed=0
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git stash push --include-untracked --quiet
+            stashed=1
+          fi
+
           git checkout -B main origin/main
+
+          if [[ "$stashed" -eq 1 ]]; then
+            if ! git stash pop --quiet; then
+              git stash apply --quiet
+              git stash drop --quiet
+            fi
+          fi
 
           shopt -s nullglob
           files=(reports/*.md)


### PR DESCRIPTION
## Summary
- stash workflow changes before syncing with origin/main to avoid untracked file checkout failures
- restore the stashed report artifacts after updating the branch so commits proceed reliably

## Testing
- python -m compileall src *(fails: existing SyntaxError in src/nofe/calibrate_truth.py)*

------
https://chatgpt.com/codex/tasks/task_e_68f7fafed63083318891eea0d2039105