### PR TITLE
Require newer OpenAI SDK for reasoning support

### DIFF
--- a/AI_ANALYSIS_README.md
+++ b/AI_ANALYSIS_README.md
@@ -29,7 +29,7 @@ ai_model: "gpt-5.1"            # OpenAI reasoning model to use (optional)
   - `true`: Appends AI analysis to the main CHAOS report
 - **`ai_model`**: Specifies which OpenAI model to use (defaults to the GPT-5.1 reasoning model with `reasoning_effort="none"` and automatic fallback)
 
-> **Reasoning configuration:** GPT-5.1 is a reasoning-capable model. The NOFE integration explicitly calls it with `reasoning_effort="none"` to minimize latency and cost while still enabling the upgraded reasoning stack. You can override this behavior by providing a custom `ai_model` or modifying the configuration if you need deeper reasoning passes.
+> **Reasoning configuration:** GPT-5.1 is a reasoning-capable model. The NOFE integration explicitly calls it with `reasoning_effort="none"` to minimize latency and cost while still enabling the upgraded reasoning stack. You can override this behavior by providing a custom `ai_model` or modifying the configuration if you need deeper reasoning passes. Install OpenAI Python SDK `>=1.54.0` so the chat completions endpoint accepts the `reasoning` parameter; older releases will raise an "unexpected keyword argument 'reasoning'" error.
 
 ## API Key Setup
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Reports will be generated in `reports/` as `CHAOS_YYYYMMDD.md`.
 
 ### AI Analysis Model
 
-If you enable the optional AI analysis module, NOFE will default to OpenAI's GPT-5.1 reasoning model (invoked with `reasoning_effort="none"`). You can adjust the `ai_model` value in `src/nofe/config.yaml` if you need to target a different release.
+If you enable the optional AI analysis module, NOFE will default to OpenAI's GPT-5.1 reasoning model (invoked with `reasoning_effort="none"`). You can adjust the `ai_model` value in `src/nofe/config.yaml` if you need to target a different release. Be sure to install the OpenAI Python SDK version `1.54.0` or newer so the chat completions API accepts the `reasoning` parameter used by GPT-5.1.
 
 ## GitHub Actions Automation
 A workflow is provided in `.github/workflows/nofe_daily.yml` to automatically run the pipeline daily, commit the results to the repo, and push to the `main` branch.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pyyaml==6.0.2
 jinja2==3.1.4
 nltk==3.8.1
 spacy>=3.6
-openai>=1.0.0
+openai>=1.54.0


### PR DESCRIPTION
## Summary
- bump the OpenAI SDK dependency to 1.54.0+ so chat completions accepts the reasoning parameter used by GPT-5.1
- document the minimum OpenAI SDK version needed for the AI analysis reasoning configuration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a3d8aa5cc8331a3e60967bbfb178d)