### PR TITLE
Fix NOFE runtime imports and NLTK dependency

### DIFF
--- a/src/nofe/analysis.py
+++ b/src/nofe/analysis.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, asdict
 from typing import Dict, Tuple
+import nltk
 from nltk.sentiment import SentimentIntensityAnalyzer
 
 try:
@@ -42,7 +43,13 @@ def _score_historical(text: str) -> float:
 
 class NightwalkerAgentStack:
     def __init__(self):
-        self.sent = SentimentIntensityAnalyzer()
+        try:
+            self.sent = SentimentIntensityAnalyzer()
+        except LookupError:
+            # Auto-fetch the VADER lexicon if it is missing so the runtime does
+            # not crash when the NLTK data has not been pre-downloaded.
+            nltk.download("vader_lexicon", quiet=True)
+            self.sent = SentimentIntensityAnalyzer()
         # initialize spaCy model once if available
         self.nlp = _NLP_MODEL
 

--- a/src/nofe/pipeline.py
+++ b/src/nofe/pipeline.py
@@ -1,15 +1,22 @@
-import yaml
 import os
-from datetime import datetime, timezone
-from pathlib import Path
-from jinja2 import Template
+import sys
 from collections import Counter
+from datetime import datetime, timezone
 from itertools import combinations
+from pathlib import Path
 
-from nofe.ingestion import fetch_rss
-from nofe.analysis import NightwalkerAgentStack, evaluate_truth_vector
+import yaml
+from jinja2 import Template
+
+# Ensure `src/` is on the import path so `python src/nofe/pipeline.py` works
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from nofe.ai_analysis import generate_ai_analysis  # assumes you’ve implemented this
                                                    # as described earlier
+from nofe.analysis import NightwalkerAgentStack, evaluate_truth_vector
+from nofe.ingestion import fetch_rss
 
 # Paths relative to this file; BASE points to src/nofe, ROOT is the repo root
 BASE = os.path.dirname(os.path.dirname(__file__))

--- a/src/nofe/pipeline2.py
+++ b/src/nofe/pipeline2.py
@@ -1,12 +1,21 @@
-import yaml, os
-from datetime import datetime, timezone
-from jinja2 import Template
-from nofe.ingestion import fetch_rss
-from nofe.analysis import NightwalkerAgentStack, evaluate_truth_vector
-from collections import Counter
-from itertools import combinations
 import csv
+import os
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from itertools import combinations
 import pathlib
+
+import yaml
+from jinja2 import Template
+
+# Ensure `src/` is on the import path so running the script directly works
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from nofe.analysis import NightwalkerAgentStack, evaluate_truth_vector
+from nofe.ingestion import fetch_rss
 
 BASE = os.path.dirname(os.path.dirname(__file__))
 ROOT = os.path.dirname(BASE)


### PR DESCRIPTION
## Summary
- ensure the pipeline entrypoints add the src directory to the import path so they work when run directly
- auto-download the NLTK VADER lexicon to prevent crashes when sentiment data is missing

## Testing
- python src/nofe/pipeline.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a48ac9db08331986a1881c6630d98)